### PR TITLE
Fix assertion failure detection on Mac OS X

### DIFF
--- a/test-gen.sh
+++ b/test-gen.sh
@@ -101,6 +101,15 @@ case $PROP in
     ;;
 esac
 
+case `uname` in
+  Darwin)
+    assertion_failure_pattern="Assertion failed: (0), function __VERIFIER_error"
+    ;;
+  *)
+    assertion_failure_pattern="tester: .* __VERIFIER_error.*: Assertion \`0' failed."
+    ;;
+esac
+
 ec=0
 make -f tester.mk BUILD_FLAGS="-g $BIT_WIDTH -std=c99 -fgnu89-inline $SAN_OPTS" > log 2>&1 || ec=$?
 # be safe and generate one
@@ -108,7 +117,7 @@ touch harness.c
 cp harness.c $SCRIPTDIR/
 case $PROP in
   unreach_call)
-    if ! grep -q "tester: .* __VERIFIER_error.*: Assertion \`0' failed." log ; then
+    if ! grep -q "$assertion_failure_pattern" log; then
       cat log 1>&2
       echo "$BM: ERROR - failing assertion not found" 1>&2
       if [ $ec -eq 0 ] ; then


### PR DESCRIPTION
The pattern used to match assertion failures doesn't match on Mac OS X (tested on Mojave 10.14.3). 

This pull request adds a different pattern for use on this OS. With this version I am able to successfully validate violation witnesses on both Mac OS X and a Linux-based Docker setup.